### PR TITLE
Fixes URL in summertraining16 page

### DIFF
--- a/content/summertraining16/contents.lr
+++ b/content/summertraining16/contents.lr
@@ -77,7 +77,7 @@ Below is a list of guest speakers in 2016 (sessions already happened).
 * [Trishna Guha](https://trishnag.wordpress.com/)
 * [Farhaan Bukhsh](https://farhaanbukhsh.wordpress.com/)
 * Huzaifa Sidhpurwala
-* [Bryan Behrenshausen](www.semioticrobotic.net)
+* [Bryan Behrenshausen](http://www.semioticrobotic.net)
 * [Justin W. Flory](https://blog.justinwflory.com/)
 * [Guido van Rossum](https://python.org)
 


### PR DESCRIPTION
This fixes the broken URL for Guest Speaker Bryan Behrenshausen's website in summertraining16 page.