### PR TITLE
fixes broken link to summertraining docs irc page

### DIFF
--- a/content/summertraining18/contents.lr
+++ b/content/summertraining18/contents.lr
@@ -101,7 +101,7 @@ Kushal Das <kushaldas AT gmail DOT com>
 
 First join the mailing list (link given below), and then the IRC channel. If
 you need help with IRC, read this
-[guide](http://summertraining.readthedocs.io/en/latest/xchat.html#xchat-or-hexchat).
+[guide](http://summertraining.readthedocs.io/en/latest/irc.html#hexchat).
 Remember, that all important details will be sent to the mailing list, so join
 there first is a good idea.
 


### PR DESCRIPTION
During refactorisation of the summertraining docs, the `xchat.html` seems to be replaced by a more comprehensive `irc.html`. This PR updates the Summertraining 2018 link.