### PR TITLE
add wiki entries for new summer trainings

### DIFF
--- a/content/wiki/contents.lr
+++ b/content/wiki/contents.lr
@@ -5,7 +5,10 @@ body:
 
 ## Links to other pages
 
-* [Summer Training16](/summertraining16/)
+* [Summer Training 2016](/summertraining16/)
+* [Summer Training 2017](/summertraining17/)
+* [Summer Training 2018](/summertraining18/)
+* [Summer Training 2019](/summertraining19/)
 * [Services](/wiki/services/)
 
 ## How to edit the wiki?


### PR DESCRIPTION
added wiki entries for summer trainings after 2016. Since this page is linked to the dgplug.org page, it makes sense to keep it updated IMHO.